### PR TITLE
Use original Amount by default.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,9 +50,9 @@ async function main() {
 
   // Prepare data object to print into file (discard unneeded fields)
   const paymentsData = payments.map(
-    ({ amount, amountOriginal, receiver, tokenAddress }) => ({
+    ({ amount, amountRounded, receiver, tokenAddress }) => ({
       amount: amount.toString(10),
-      amountOriginal: amountOriginal.toString(10),
+      amountRounded: amountRounded.toString(10),
       receiver,
       tokenAddress,
     })

--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,8 @@ function toPayment(leaderBoardItem) {
   return {
     tokenAddress: GNO_ADDRESS,
     receiver,
-    amountOriginal,
-    amount: amountRounded,
+    amountRounded,
+    amount: amountOriginal,
   };
 }
 


### PR DESCRIPTION
In previous token distribution, we rounded up to the next whole integer. We don't want this to be the default, so this quick fix adjusts that.